### PR TITLE
Added OS X Wurst-Bot Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Getting an error saying that `java` is not a known command? [Fix your PATH varia
 ##### OSX #####
 
 To run open a terminal and type
-`chmod +x ` then drag and drop the file into the terminal and press ENTER (dont forget the space after the x)
+`chmod +x ` then drag and drop startOSX into the terminal and press ENTER (dont forget the space after the x)
 
-finally Right-click > Open With > Terminal
+finally Right-click startOSX > Open With > Terminal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Wurst-Bot launcher
 A basic launcher for Wurst-Bot
 
-#### This is is only a launcher. Wurst-Bot itself is part of the [Wurst Client](https://www.wurst-client.tk/).
+#### This project is only a launcher. Wurst-Bot itself is part of the [Wurst Client](https://www.wurst-client.tk/).
+
+##### Windows #####
 
 Getting an error saying that `java` is not a known command? [Fix your PATH variable.](http://bit.ly/1cHAyTA)
+
+##### OSX #####
+
+To run open a terminal and type
+`chmod +x ` then drag and drop the file into the terminal and press ENTER (dont forget the space after the x)
+
+finally Right-click > Open With > Terminal

--- a/startOSX.sh
+++ b/startOSX.sh
@@ -1,0 +1,64 @@
+###########
+#minepath="~/Library/Application\ Support/minecraft/versions"
+
+function vanillaJAR() {
+	echo -n "Processing vanilla jar..   "
+	if [ ! -f "~/Library/Application\ Support/minecraft/versions/Wurst/Wurst-Bot/Wurst-Bot_lib/1.8.jar" ]
+		then
+		cp ~/Library/Application\ Support/minecraft/versions/1.8/1.8.jar ~/Library/Application\ Support/minecraft/versions/Wurst/Wurst-Bot/Wurst-Bot_lib/1.8.jar
+		if [ $? = 0 ]
+			then
+			echo "[OK]"
+			return 0
+		else
+			echo "[FAILED]"
+			echo "Please start Minecraft with version 1.8 (no 1.8.x)"
+			exit 1
+		fi
+	else
+		echo "[OK]"
+		return 0
+	fi }
+
+function wurstJAR() {
+	echo -n "Processing Wurst jar..     "
+	if [ ! -f "~/Library/Application\ Support/minecraft/versions/Wurst/Wurst-Bot/Wurst.jar " ]
+		then
+		cp ~/Library/Application\ Support/minecraft/versions/Wurst/Wurst.jar ~/Library/Application\ Support/minecraft/versions/Wurst/Wurst-Bot/Wurst.jar 
+		if [ $? = 0 ]
+			then
+			echo "[OK]"
+			return 0
+		else
+			echo "[FAILED]"
+			echo "Error copying Wurst Jar.."
+			echo "Please put a copy of the Wurst Client JAR file ^(v1.11 or higher^) into the minecraft/versions/Wurst folder."
+			exit 1
+		fi
+	else
+		echo "[OK]"
+		return 0
+	fi	}
+	
+function cleanUP() {
+	if [ ! -f "~/Library/Application\ Support/minecraft/versions/Wurst/Wurst-Bot/Wurst-Bot.jar" ]
+		then
+		rm ~/Library/Application\ Support/minecraft/versions/Wurst/Wurst-Bot/Wurst-Bot.jar
+	fi
+	mv ~/Library/Application\ Support/minecraft/versions/Wurst/Wurst-Bot/Wurst.jar ~/Library/Application\ Support/minecraft/versions/Wurst/Wurst-Bot/Wurst-Bot.jar
+	echo "Cleaning Up.."
+	sleep 3
+	}
+	
+echo Starting Wurst-Bot launcher..
+	Sleep 4
+	clear
+	vanillaJAR
+	wurstJAR
+cleanUP
+java -jar ~/Library/Application\ Support/minecraft/versions/Wurst/Wurst-Bot/Wurst-Bot.jar
+		
+		
+		
+		
+	


### PR DESCRIPTION
Added file startOSX.sh, made it based on start.bat script commands.
Note: Works only with standard OS X installations of minecraft, will add Linux script later.
